### PR TITLE
Ensure original render as works

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.1.1
+
+* Make renderAs as prop work with other renderAs components
+
 ## 0.1.0
 
 * Package created

--- a/lib/render-as.js
+++ b/lib/render-as.js
@@ -21,7 +21,7 @@ export const renderAs = (DefaultAs: React.ElementType) => {
       Component = as;
     }
 
-    if (/renderAs\(.+\)/.test(DefaultAs.displayName)) {
+    if (DefaultAs.renderAs) {
       return (
         <DefaultAs as={as} {...rest}>
           {rest.children}
@@ -39,6 +39,7 @@ export const renderAs = (DefaultAs: React.ElementType) => {
     : DefaultAs.displayName || DefaultAs.name || 'Component';
 
   AsableComponent.displayName = `renderAs(${displayName})`;
+  AsableComponent.renderAs = true;
   AsableComponent.defaultProps = {
     as: DefaultAs
   };

--- a/lib/render-as.js
+++ b/lib/render-as.js
@@ -22,8 +22,10 @@ export const renderAs = (DefaultAs: React.ElementType) => {
     }
 
     if (/renderAs\(.+\)/.test(DefaultAs.displayName)) {
-      rest.as = (
-        <DefaultAs as={as} />
+      return (
+        <DefaultAs as={as} {...rest}>
+          {rest.children}
+        </DefaultAs>
       );
     }
 

--- a/lib/render-as.js
+++ b/lib/render-as.js
@@ -13,7 +13,10 @@ export const renderAs = (DefaultAs: React.ElementType) => {
 
     if (DefaultAs.renderAs) {
       return (
-        <DefaultAs as={as} {...rest}>
+        <DefaultAs
+          as={as === DefaultAs ? DefaultAs.defaultProps.as : as}
+          {...rest}
+        >
           {rest.children}
         </DefaultAs>
       );

--- a/lib/render-as.js
+++ b/lib/render-as.js
@@ -7,7 +7,7 @@ type AsableProps = {
   [string]: any
 };
 
-export const renderAs = (defaultAs: React.ElementType) => {
+export const renderAs = (DefaultAs: React.ElementType) => {
   const AsableComponent = (props: AsableProps): React.Node => {
     const { as, ...rest } = props;
     let Component;
@@ -21,18 +21,24 @@ export const renderAs = (defaultAs: React.ElementType) => {
       Component = as;
     }
 
+    if (/renderAs\(.+\)/.test(DefaultAs.displayName)) {
+      rest.as = (
+        <DefaultAs as={as} />
+      );
+    }
+
     return /* $FlowFixMe */ (
       <Component {...rest}>{rest.children}</Component>
     );
   };
 
-  const displayName = typeof defaultAs === 'string'
-    ? defaultAs
-    : defaultAs.displayName || defaultAs.name || 'Component';
+  const displayName = typeof DefaultAs === 'string'
+    ? DefaultAs
+    : DefaultAs.displayName || DefaultAs.name || 'Component';
 
   AsableComponent.displayName = `renderAs(${displayName})`;
   AsableComponent.defaultProps = {
-    as: defaultAs
+    as: DefaultAs
   };
 
   return AsableComponent;

--- a/lib/render-as.js
+++ b/lib/render-as.js
@@ -10,6 +10,15 @@ type AsableProps = {
 export const renderAs = (DefaultAs: React.ElementType) => {
   const AsableComponent = (props: AsableProps): React.Node => {
     const { as, ...rest } = props;
+
+    if (DefaultAs.renderAs) {
+      return (
+        <DefaultAs as={as} {...rest}>
+          {rest.children}
+        </DefaultAs>
+      );
+    }
+
     let Component;
 
     if (React.isValidElement(as)) {
@@ -19,14 +28,6 @@ export const renderAs = (DefaultAs: React.ElementType) => {
       Object.assign(rest, as.props);
     } else {
       Component = as;
-    }
-
-    if (DefaultAs.renderAs) {
-      return (
-        <DefaultAs as={as} {...rest}>
-          {rest.children}
-        </DefaultAs>
-      );
     }
 
     return /* $FlowFixMe */ (

--- a/lib/render-as.js
+++ b/lib/render-as.js
@@ -11,10 +11,14 @@ export const renderAs = (DefaultAs: React.ElementType) => {
   const AsableComponent = (props: AsableProps): React.Node => {
     const { as, ...rest } = props;
 
+    // $FlowFixMe
     if (DefaultAs.renderAs) {
       return (
         <DefaultAs
-          as={as === DefaultAs ? DefaultAs.defaultProps.as : as}
+          as={
+            /* $FlowFixMe */
+            as === DefaultAs ? DefaultAs.defaultProps.as : as
+          }
           {...rest}
         >
           {rest.children}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-render-as",
   "description": "Utility for creating components which accept the `as` prop in React",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Sam Boylett <sam.boylett@piksel.com>",
   "main": "dist/index.js",
   "scripts": {

--- a/test/spec/render-as.js
+++ b/test/spec/render-as.js
@@ -196,14 +196,17 @@ describe('renderAs', () => {
       WrappedRenderAs = renderAs('div');
       Component = renderAs(WrappedRenderAs);
 
-      component = mount(<Component />);
+      component = mount(<Component as={WrappedRenderAs} />);
     });
 
     sharedTests('div');
 
     it('will render the original renderAs', () => {
-      console.log(component.debug(), WrappedRenderAs.displayName);
       expect(component.find(WrappedRenderAs)).toHaveLength(1);
+    });
+
+    it('sets the original renderAs as prop to its default', () => {
+      expect(component.find(WrappedRenderAs)).toHaveProp('as', 'div');
     });
 
     describe('when as set', () => {

--- a/test/spec/render-as.js
+++ b/test/spec/render-as.js
@@ -189,10 +189,31 @@ describe('renderAs', () => {
   });
 
   describe('when passed another renderAs component', () => {
+    let WrappedRenderAs;
+    let component;
+
     beforeEach(() => {
-      Component = renderAs(renderAs(TestFunctionalComponent));
+      WrappedRenderAs = renderAs('div');
+      Component = renderAs(WrappedRenderAs);
+
+      component = mount(<Component />);
     });
 
-    sharedTests(TestFunctionalComponent);
+    sharedTests('div');
+
+    it('will render the original renderAs', () => {
+      console.log(component.debug(), WrappedRenderAs.displayName);
+      expect(component.find(WrappedRenderAs)).toHaveLength(1);
+    });
+
+    describe('when as set', () => {
+      beforeEach(() => {
+        component.setProps({ as: 'p' });
+      });
+
+      it('renders the wrapped render as with the new as prop', () => {
+        expect(component.find(WrappedRenderAs)).toHaveProp('as', 'p');
+      });
+    });
   });
 });

--- a/test/spec/render-as.js
+++ b/test/spec/render-as.js
@@ -187,4 +187,12 @@ describe('renderAs', () => {
 
     sharedTests(TestFunctionalComponent);
   });
+
+  describe('when passed another renderAs component', () => {
+    beforeEach(() => {
+      Component = renderAs(renderAs(TestFunctionalComponent));
+    });
+
+    sharedTests(TestFunctionalComponent);
+  });
 });


### PR DESCRIPTION
This PR adds additional logic as when a renderAs default `as` prop is set to another renderAs component, that component is instead rendered with whatever `as` value is used on the original renderAs, but defaults to the wrapped renderAs's default as prop.